### PR TITLE
[WIP] [Feature] Add pyproject_rocm.toml for end-to-end ROCm pip installation support

### DIFF
--- a/docs/platforms/amd_gpu.md
+++ b/docs/platforms/amd_gpu.md
@@ -40,23 +40,6 @@ Again, please go through the entire documentation to confirm your system is usin
 
 You can install SGLang using one of the methods below.
 
-### Install from Source
-
-```bash
-# Use the last release branch
-git clone -b v0.5.3 https://github.com/sgl-project/sglang.git
-cd sglang
-
-# Compile sgl-kernel
-pip install --upgrade pip
-cd sgl-kernel
-python setup_rocm.py install
-
-# Install sglang python package
-cd ..
-pip install -e "python[all_hip]"
-```
-
 ### Install Using Docker (Recommended)
 
 The docker images are available on Docker Hub at [lmsysorg/sglang](https://hub.docker.com/r/lmsysorg/sglang/tags), built from [Dockerfile.rocm](https://github.com/sgl-project/sglang/tree/main/docker).
@@ -112,6 +95,24 @@ The steps below show how to build and use an image.
    ```
 
 With your AMD system properly configured and SGLang installed, you can now fully leverage AMD hardware to power SGLang’s machine learning capabilities.
+
+### Install from Source
+
+```bash
+# Use the last release branch
+git clone -b v0.5.5.post1 https://github.com/sgl-project/sglang.git
+cd sglang
+
+# Compile sgl-kernel
+pip install --upgrade pip
+cd sgl-kernel
+python setup_rocm.py install
+
+# Install sglang python package
+cd ..
+rm -rf python/pyproject.toml && mv python/pyproject_rocm.toml python/pyproject.toml
+pip install -e "python[rocm700]" # or pip install -e "python[rocm640]"
+```
 
 ## Examples
 

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -105,9 +105,9 @@ tracing = [
 ]
 
 630_all = [
-  "sglang[test]",
-  "sglang[decord]",
-  "sglang[630]"
+  "sglang-rocm[test]",
+  "sglang-rocm[decord]",
+  "sglang-rocm[630]"
 ]
 
 700 = [
@@ -134,9 +134,9 @@ tracing = [
 ]
 
 700_all = [
-  "sglang[test]",
-  "sglang[decord]",
-  "sglang[700]"
+  "sglang-rocm[test]",
+  "sglang-rocm[decord]",
+  "sglang-rocm[700]"
 ]
 
 [project.urls]

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -99,6 +99,7 @@ rocm630 = [
     "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp314-cp314-linux_x86_64.whl ; python_version == '3.14'",
     "sgl-kernel-rocm630-torch290 @ https://test-files.pythonhosted.org/packages/94/6c/044d1206ac906c4cdac40a806cab3a8a08207e0a79eec84e4555dda9df06/sgl_kernel_rocm630_torch290-0.3.15.post1-cp310-abi3-manylinux2014_x86_64.whl",
     "compressed-tensors",
+    "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
     "xgrammar==0.1.25"
@@ -122,6 +123,7 @@ rocm700 = [
     "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp314-cp314-linux_x86_64.whl ; python_version == '3.14'",
     "sgl-kernel-rocm700-torch210 @ https://test-files.pythonhosted.org/packages/aa/69/cd336d660e15884af8f2a829716526ea19ecd1dd826fa3e94f009eeca48f/sgl_kernel_rocm700_torch210-0.3.15.post5-cp310-abi3-manylinux2014_x86_64.whl",
     "compressed-tensors",
+    "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
     "xgrammar==0.1.25"

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -120,7 +120,7 @@ rocm700 = [
     "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp312-cp312-linux_x86_64.whl ; python_version == '3.12'",
     "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp313-cp313-linux_x86_64.whl ; python_version == '3.13'",
     "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp314-cp314-linux_x86_64.whl ; python_version == '3.14'",
-    "sgl-kernel-rocm700-torch210 @ https://test-files.pythonhosted.org/packages/a1/49/83b14d328ee3d906956015c7116534e625fe923284cbc41546773494f5bd/sgl_kernel_rocm700_torch210-0.3.15.post1-cp310-abi3-manylinux2014_x86_64.whl",
+    "sgl-kernel-rocm700-torch210 @ https://test-files.pythonhosted.org/packages/aa/69/cd336d660e15884af8f2a829716526ea19ecd1dd826fa3e94f009eeca48f/sgl_kernel_rocm700_torch210-0.3.15.post5-cp310-abi3-manylinux2014_x86_64.whl",
     "compressed-tensors",
     "outlines==0.1.11",
     "timm==1.0.16",

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -61,7 +61,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-decord = ["decord2"]
+decord = ["decord2==2.0.0"]
 test = [
   "accelerate",
   "expecttest",
@@ -144,7 +144,7 @@ tracing = [
 "Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
 
 [tool.setuptools.package-data]
-"sglang-rocm" = [
+"sglang" = [
   "srt/layers/moe/fused_moe_triton/configs/*/*.json",
   "srt/layers/quantization/configs/*.json",
   "srt/mem_cache/storage/hf3fs/hf3fs_utils.cpp",

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -1,0 +1,179 @@
+[build-system]
+requires = ["setuptools>=61.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "sglang-rocm"
+version = "0.5.3.post2"
+description = "SGLang is a fast serving framework for large language models and vision language models."
+readme = "README.md"
+requires-python = ">=3.10"
+license = { file = "LICENSE" }
+classifiers = [
+  "Programming Language :: Python :: 3",
+  "License :: OSI Approved :: Apache Software License",
+]
+dependencies = [
+  "IPython",
+  "aiohttp",
+  "anthropic>=0.20.0",
+  "blobfile==3.0.0",
+  "build",
+  "datasets",
+  "einops",
+  "fastapi",
+  "hf_transfer",
+  "huggingface_hub",
+  "interegular",
+  "llguidance>=0.7.11,<0.8.0",
+  "modelscope",
+  "msgspec",
+  "ninja",
+  "numpy",
+  "openai-harmony==0.0.4",
+  "openai==1.99.1",
+  "orjson",
+  "packaging",
+  "partial_json_parser",
+  "pillow",
+  "prometheus-client>=0.20.0",
+  "psutil",
+  "py-spy",
+  "pybase64",
+  "pydantic",
+  "python-multipart",
+  "pyzmq>=25.1.2",
+  "requests",
+  "scipy",
+  "sentencepiece",
+  "setproctitle",
+  "soundfile==0.13.1",
+  "tiktoken",
+  "torch_memory_saver==0.0.9rc2",
+  "torchao==0.9.0",
+  "tqdm",
+  "transformers==4.57.1",
+  "uvicorn",
+  "uvloop",
+  "grpcio==1.75.1", # keep it align with compile_proto.py
+  "grpcio-tools==1.75.1", # keep it align with compile_proto.py
+  "grpcio-reflection==1.75.1", # required by srt/entrypoints/grpc_server.py
+]
+
+[project.optional-dependencies]
+decord = ["decord2"]
+test = [
+  "accelerate",
+  "expecttest",
+  "gguf",
+  "jsonlines",
+  "matplotlib",
+  "pandas",
+  "peft",
+  "pytest",
+  "sentence_transformers",
+  "tabulate",
+]
+tracing = [
+  "opentelemetry-api",
+  "opentelemetry-exporter-otlp",
+  "opentelemetry-exporter-otlp-proto-grpc",
+  "opentelemetry-sdk",
+]
+
+630 = [
+    "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
+    "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
+    "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",
+    "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp313-cp313-manylinux_2_28_x86_64.whl ; python_version == '3.13'",
+    "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp314-cp314-manylinux_2_28_x86_64.whl ; python_version == '3.14'",
+    "torchvision @ https://download.pytorch.org/whl/rocm6.4/torchvision-0.24.0%2Brocm6.4-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
+    "torchvision @ https://download.pytorch.org/whl/rocm6.4/torchvision-0.24.0%2Brocm6.4-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
+    "torchvision @ https://download.pytorch.org/whl/rocm6.4/torchvision-0.24.0%2Brocm6.4-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",
+    "torchvision @ https://download.pytorch.org/whl/rocm6.4/torchvision-0.24.0%2Brocm6.4-cp313-cp313-manylinux_2_28_x86_64.whl ; python_version == '3.13'",
+    "torchvision @ https://download.pytorch.org/whl/rocm6.4/torchvision-0.24.0%2Brocm6.4-cp314-cp314-manylinux_2_28_x86_64.whl ; python_version == '3.14'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp310-cp310-linux_x86_64.whl ; python_version == '3.10'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp311-cp311-linux_x86_64.whl ; python_version == '3.11'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp312-cp312-linux_x86_64.whl ; python_version == '3.12'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp313-cp313-linux_x86_64.whl ; python_version == '3.13'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/pytorch_triton_rocm-3.5.0-cp314-cp314-linux_x86_64.whl ; python_version == '3.14'",
+    "sgl-kernel-rocm630-torch290 @ https://test-files.pythonhosted.org/packages/94/6c/044d1206ac906c4cdac40a806cab3a8a08207e0a79eec84e4555dda9df06/sgl_kernel_rocm630_torch290-0.3.15.post1-cp310-abi3-manylinux2014_x86_64.whl",
+    "compressed-tensors",
+    "outlines==0.1.11",
+    "timm==1.0.16",
+    "xgrammar==0.1.25"
+]
+
+630_all = [
+  "sglang[test]",
+  "sglang[decord]",
+  "sglang[630]"
+]
+
+700 = [
+    "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
+    "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
+    "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",
+    "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp313-cp313-manylinux_2_28_x86_64.whl ; python_version == '3.13'",
+    "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp314-cp314-manylinux_2_28_x86_64.whl ; python_version == '3.14'",
+    "torchvision @ https://download.pytorch.org/whl/nightly/rocm7.0/torchvision-0.25.0.dev20251012%2Brocm7.0-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
+    "torchvision @ https://download.pytorch.org/whl/nightly/rocm7.0/torchvision-0.25.0.dev20251012%2Brocm7.0-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
+    "torchvision @ https://download.pytorch.org/whl/nightly/rocm7.0/torchvision-0.25.0.dev20251012%2Brocm7.0-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",
+    "torchvision @ https://download.pytorch.org/whl/nightly/rocm7.0/torchvision-0.25.0.dev20251012%2Brocm7.0-cp313-cp313-manylinux_2_28_x86_64.whl ; python_version == '3.13'",
+    "torchvision @ https://download.pytorch.org/whl/nightly/rocm7.0/torchvision-0.25.0.dev20251012%2Brocm7.0-cp314-cp314-manylinux_2_28_x86_64.whl ; python_version == '3.14'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp310-cp310-linux_x86_64.whl ; python_version == '3.10'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp311-cp311-linux_x86_64.whl ; python_version == '3.11'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp312-cp312-linux_x86_64.whl ; python_version == '3.12'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp313-cp313-linux_x86_64.whl ; python_version == '3.13'",
+    "pytorch-triton-rocm @ https://download.pytorch.org/whl/nightly/pytorch_triton_rocm-3.5.0%2Bgit7416ffcb-cp314-cp314-linux_x86_64.whl ; python_version == '3.14'",
+    "sgl-kernel-rocm700-torch210 @ https://test-files.pythonhosted.org/packages/a1/49/83b14d328ee3d906956015c7116534e625fe923284cbc41546773494f5bd/sgl_kernel_rocm700_torch210-0.3.15.post1-cp310-abi3-manylinux2014_x86_64.whl",
+    "compressed-tensors",
+    "outlines==0.1.11",
+    "timm==1.0.16",
+    "xgrammar==0.1.25"
+]
+
+700_all = [
+  "sglang[test]",
+  "sglang[decord]",
+  "sglang[700]"
+]
+
+[project.urls]
+"Homepage" = "https://github.com/sgl-project/sglang"
+"Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
+
+[tool.setuptools.package-data]
+"sglang" = [
+  "srt/layers/moe/fused_moe_triton/configs/*/*.json",
+  "srt/layers/quantization/configs/*.json",
+  "srt/mem_cache/storage/hf3fs/hf3fs_utils.cpp",
+  "srt/speculative/cpp_ngram/*.cpp",
+  "srt/speculative/cpp_ngram/*.h",
+]
+
+[tool.setuptools.packages.find]
+exclude = [
+  "assets*",
+  "benchmark*",
+  "docs*",
+  "dist*",
+  "playground*",
+  "scripts*",
+  "tests*",
+]
+
+[tool.wheel]
+exclude = [
+  "assets*",
+  "benchmark*",
+  "docs*",
+  "dist*",
+  "playground*",
+  "scripts*",
+  "tests*",
+]
+
+[tool.codespell]
+ignore-words-list = "ans, als, hel, boostrap, childs, te, vas, hsa, ment"
+skip = "*.json,*.jsonl,*.patch,*.txt"

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -54,7 +54,7 @@ dependencies = [
   "tqdm",
   "transformers==4.57.1",
   "uvicorn",
-  "uvloop",
+  "uvloop==0.21.0",
   "grpcio==1.75.1", # keep it align with compile_proto.py
   "grpcio-tools==1.75.1", # keep it align with compile_proto.py
   "grpcio-reflection==1.75.1", # required by srt/entrypoints/grpc_server.py

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -103,11 +103,6 @@ tracing = [
     "xgrammar==0.1.25"
 ]
 
-630_all = [
-  "sglang-rocm[test]",
-  "sglang-rocm[630]"
-]
-
 700 = [
     "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
     "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
@@ -129,11 +124,6 @@ tracing = [
     "outlines==0.1.11",
     "timm==1.0.16",
     "xgrammar==0.1.25"
-]
-
-700_all = [
-  "sglang-rocm[test]",
-  "sglang-rocm[700]"
 ]
 
 [project.urls]

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -61,7 +61,6 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-decord = ["decord2==2.0.0"]
 test = [
   "accelerate",
   "expecttest",
@@ -106,7 +105,6 @@ tracing = [
 
 630_all = [
   "sglang-rocm[test]",
-  "sglang-rocm[decord]",
   "sglang-rocm[630]"
 ]
 
@@ -135,7 +133,6 @@ tracing = [
 
 700_all = [
   "sglang-rocm[test]",
-  "sglang-rocm[decord]",
   "sglang-rocm[700]"
 ]
 

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "sglang"
+name = "sglang-rocm"
 version = "0.5.3"
 description = "SGLang is a fast serving framework for large language models and vision language models."
 readme = "README.md"

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -144,7 +144,7 @@ tracing = [
 "Bug Tracker" = "https://github.com/sgl-project/sglang/issues"
 
 [tool.setuptools.package-data]
-"sglang" = [
+"sglang-rocm" = [
   "srt/layers/moe/fused_moe_triton/configs/*/*.json",
   "srt/layers/quantization/configs/*.json",
   "srt/mem_cache/storage/hf3fs/hf3fs_utils.cpp",

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -102,7 +102,7 @@ rocm640 = [
     "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
-    "wave-lang==3.7.0",
+    "wave-lang==3.8.2",
     "xgrammar==0.1.25"
 ]
 
@@ -127,7 +127,7 @@ rocm700 = [
     "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
-    "wave-lang==3.7.0",
+    "wave-lang==3.8.2",
     "xgrammar==0.1.25"
 ]
 

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -102,6 +102,7 @@ rocm630 = [
     "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
+    "wave-lang==3.7.0",
     "xgrammar==0.1.25"
 ]
 
@@ -126,6 +127,7 @@ rocm700 = [
     "outlines-core==0.1.26",
     "outlines==0.1.11",
     "timm==1.0.16",
+    "wave-lang==3.7.0",
     "xgrammar==0.1.25"
 ]
 

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -81,7 +81,7 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
-rocm630 = [
+rocm640 = [
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -3,8 +3,8 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "sglang-rocm"
-version = "0.5.3.post2"
+name = "sglang"
+version = "0.5.3"
 description = "SGLang is a fast serving framework for large language models and vision language models."
 readme = "README.md"
 requires-python = ">=3.10"

--- a/python/pyproject_rocm.toml
+++ b/python/pyproject_rocm.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=61.0", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "sglang-rocm"
+name = "sglang"
 version = "0.5.3"
 description = "SGLang is a fast serving framework for large language models and vision language models."
 readme = "README.md"
@@ -61,6 +61,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
+decord = ["decord2"]
 test = [
   "accelerate",
   "expecttest",
@@ -80,7 +81,7 @@ tracing = [
   "opentelemetry-sdk",
 ]
 
-630 = [
+rocm630 = [
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
     "torch @ https://download.pytorch.org/whl/rocm6.4/torch-2.9.0%2Brocm6.4-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",
@@ -103,7 +104,7 @@ tracing = [
     "xgrammar==0.1.25"
 ]
 
-700 = [
+rocm700 = [
     "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp310-cp310-manylinux_2_28_x86_64.whl ; python_version == '3.10'",
     "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp311-cp311-manylinux_2_28_x86_64.whl ; python_version == '3.11'",
     "torch @ https://download.pytorch.org/whl/nightly/rocm7.0/torch-2.10.0.dev20251011%2Brocm7.0-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12'",


### PR DESCRIPTION
## Motivation

To enable **end-to-end** `pip install sglang` support for ROCm, this PR adds the necessary **ROCm-specific build configuration file, `pyproject_rocm.toml`**.

---

## Accuracy Tests

Tested on the following matrix:
* **ROCm Versions**: [6.4, 7.0]
* **Python Versions**: [3.10, 3.11, 3.12]
* **Hardware**: [MI300, MI350]

---

## Checklist

- [x] Format your code according to the [Format code with pre-commit](https://docs.sglang.ai/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [x] Update documentation according to [Write documentations](https://docs.sglang.ai/developer_guide/contribution_guide.html#write-documentations).
- [ ] Replace `sgl-kernel` URL with upstream once [Adding pip install Support for sgl-kernel for ROCm](https://github.com/hubertlu-tw/sglang/pull/1) is merged.
- [ ] Add GitHub action code to build and upload sglang wheel to index of choice.
- [ ] Change PR title to reflect ROCm SGLang wheel support.