### PR TITLE
[AMD] Fix draft-decode seqused_k in aiter unified_attention

### DIFF
--- a/python/sglang/srt/layers/attention/aiter_backend.py
+++ b/python/sglang/srt/layers/attention/aiter_backend.py
@@ -103,6 +103,12 @@ class ForwardMetadata:
     max_extend_len: Optional[int] = None
     fp8_prefill_kv_indices: Optional[torch.Tensor] = None
     swa_page_table: Optional[torch.Tensor] = None
+    # Per-row used kv length for the draft-decode unified-attention path.
+    # forward_batch.seq_lens is the target's per-request prefix length and
+    # does not include draft tokens committed in earlier draft steps of the
+    # same round; passing it to unified_attention as seqused_k drops those
+    # tokens from the attention window and lowers accept length.
+    seqused_k: Optional[torch.Tensor] = None
 
 
 global_workspace_buffer = None
@@ -611,6 +617,7 @@ class AiterAttnBackend(AttentionBackend):
         bs: int,
         dest_buf: Optional[torch.Tensor] = None,
         swa_dest_buf: Optional[torch.Tensor] = None,
+        seqused_k_buf: Optional[torch.Tensor] = None,
     ) -> torch.Tensor:
         """Convert ragged (token-level) kv_indices from spec_info into a 2D
         block-level page_table of shape (bs, max_num_blocks_per_seq).
@@ -646,6 +653,21 @@ class AiterAttnBackend(AttentionBackend):
                     bs, max_blocks, dtype=torch.int32, device=self.device
                 )
 
+        # Materialize per-row used kv length from the ragged indptr so that
+        # draft step i correctly attends to prefix + i tokens (the draft
+        # kv of earlier steps is already committed via set_kv_buffer).
+        if seqused_k_buf is not None:
+            # Static buffer path (cuda graph): in-place subtract so the
+            # captured graph references the same data pointer at replay.
+            torch.sub(
+                kv_indptr[1 : bs + 1],
+                kv_indptr[:bs],
+                out=seqused_k_buf[:bs],
+            )
+            seqused_k = seqused_k_buf[:bs]
+        else:
+            seqused_k = (kv_indptr[1 : bs + 1] - kv_indptr[:bs]).to(torch.int32)
+
         BLOCK_SIZE = 1024
         grid = (bs, triton.cdiv(max(max_blocks, 1), BLOCK_SIZE))
         _scatter_ragged_to_page_table_kernel[grid](
@@ -660,7 +682,7 @@ class AiterAttnBackend(AttentionBackend):
             HAS_SWA=(swa_slot_mapping is not None),
         )
 
-        return page_table, swa_page_table
+        return page_table, swa_page_table, seqused_k
 
     def _build_verify_unified_metadata(
         self,
@@ -902,6 +924,7 @@ class AiterAttnBackend(AttentionBackend):
 
     def init_forward_metadata(self, forward_batch: ForwardBatch):
         """Init auxiliary variables for aiter attention backend."""
+        spec_seqused_k = None  # set by unified-attention spec-info path
 
         bs = forward_batch.batch_size
         kv_indptr = self.kv_indptr
@@ -976,7 +999,7 @@ class AiterAttnBackend(AttentionBackend):
             else:
                 if self.use_triton_unified_attention and not self.use_mla:
                     bs = spec_info.kv_indptr.shape[0] - 1
-                    kv_indices, swa_page_table = (
+                    kv_indices, swa_page_table, spec_seqused_k = (
                         self._build_unified_page_table_from_spec(spec_info, bs)
                     )
                     max_q_len = 1
@@ -1048,6 +1071,7 @@ class AiterAttnBackend(AttentionBackend):
                 num_kv_splits=num_kv_splits,
                 run_graph=False,
                 swa_page_table=swa_page_table,
+                seqused_k=spec_seqused_k,
             )
 
         elif forward_batch.forward_mode.is_draft_extend_v2():
@@ -1530,6 +1554,12 @@ class AiterAttnBackend(AttentionBackend):
                 device=self.device,
             )
 
+        # Static per-row seqused_k buffer for the spec-info unified-attention
+        # draft-decode path. Captured once so replay updates it in-place.
+        self.cuda_graph_spec_seqused_k = torch.zeros(
+            max_bs, dtype=torch.int32, device=self.device
+        )
+
     def init_forward_metadata_capture_cuda_graph(
         self,
         bs: int,
@@ -1542,6 +1572,7 @@ class AiterAttnBackend(AttentionBackend):
     ):
 
         num_kv_splits = None
+        spec_seqused_k = None  # set by unified-attention spec-info path
         # num_kv_splits_indptr = None
 
         work_metadata = None
@@ -1592,13 +1623,15 @@ class AiterAttnBackend(AttentionBackend):
                         swa_page_table = self.cuda_graph_swa_page_table
 
                     if spec_info is not None:
-                        self._build_unified_page_table_from_spec(
+                        _, _, spec_seqused_k = self._build_unified_page_table_from_spec(
                             spec_info,
                             bs,
                             dest_buf=kv_indices,
                             swa_dest_buf=swa_page_table,
+                            seqused_k_buf=self.cuda_graph_spec_seqused_k,
                         )
                     else:
+                        spec_seqused_k = None
                         page_indices = self.req_to_token[
                             req_pool_indices[:bs], :max_kv_len
                         ]
@@ -1683,6 +1716,7 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map=reduce_partial_map,
                 num_kv_splits=num_kv_splits,
                 swa_page_table=swa_page_table,
+                seqused_k=spec_seqused_k,
             )
 
         elif forward_mode.is_target_verify():
@@ -1975,6 +2009,7 @@ class AiterAttnBackend(AttentionBackend):
         spec_info: Optional[SpecInput],
         seq_lens_cpu: Optional[torch.Tensor],
     ):
+        spec_seqused_k = None  # set by unified-attention spec-info path
 
         num_kv_splits = None
         # num_kv_splits_indptr = None
@@ -2026,13 +2061,15 @@ class AiterAttnBackend(AttentionBackend):
                         swa_page_table = self.cuda_graph_swa_page_table
 
                     if spec_info is not None:
-                        self._build_unified_page_table_from_spec(
+                        _, _, spec_seqused_k = self._build_unified_page_table_from_spec(
                             spec_info,
                             bs,
                             dest_buf=kv_indices,
                             swa_dest_buf=swa_page_table,
+                            seqused_k_buf=self.cuda_graph_spec_seqused_k,
                         )
                     else:
+                        spec_seqused_k = None
                         page_indices = self.req_to_token[
                             req_pool_indices[:bs], :max_kv_len
                         ]
@@ -2117,6 +2154,7 @@ class AiterAttnBackend(AttentionBackend):
                 reduce_partial_map=reduce_partial_map,
                 num_kv_splits=num_kv_splits,
                 swa_page_table=swa_page_table,
+                seqused_k=spec_seqused_k,
                 # num_kv_splits_indptr=num_kv_splits_indptr,
             )
 
@@ -2959,6 +2997,17 @@ class AiterAttnBackend(AttentionBackend):
 
                 max_kv_len = page_table.shape[1] * self.page_size
 
+                # For the EAGLE draft-decode path forward_batch.seq_lens only
+                # reflects the target's prefix length and omits the draft
+                # tokens committed in earlier steps of the same round. When the
+                # spec-info unified path is active we use the per-row kv length
+                # we already computed from spec_info.kv_indptr.
+                seqused_k = (
+                    self.forward_metadata.seqused_k
+                    if self.forward_metadata.seqused_k is not None
+                    else forward_batch.seq_lens
+                )
+
                 unified_attention(
                     q=q.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                     k=k_cache.view(
@@ -2969,7 +3018,7 @@ class AiterAttnBackend(AttentionBackend):
                     ),
                     out=o.view(-1, layer.tp_q_head_num, layer.qk_head_dim),
                     cu_seqlens_q=self.forward_metadata.qo_indptr,
-                    seqused_k=forward_batch.seq_lens,
+                    seqused_k=seqused_k,
                     max_seqlen_q=self.forward_metadata.max_q_len,
                     max_seqlen_k=max_kv_len,
                     softmax_scale=self.scale,


### PR DESCRIPTION
Under EAGLE draft decode the forward_decode unified_attention branch was passing forward_batch.seq_lens as seqused_k. That value is the target's per-request prefix length and does not include the draft tokens that were committed to the draft KV cache in earlier steps of the same round. As a result draft step 1 / step 2 attended only over the prefix, missing the K/V the draft had just written, which cascaded into worse draft logits and noticeably lower accept length.

Compute the per-row kv length from spec_info.kv_indptr inside _build_unified_page_table_from_spec (or write it in-place into a static cuda-graph buffer), stash it on ForwardMetadata.seqused_k, and route it into the unified_attention call. The non-spec path still uses forward_batch.seq_lens unchanged.

Verified on Kimi-K2.5 MXFP4 TP8 + EAGLE3 with SGLANG_USE_AITER_UNIFIED_ATTN=1 (random 8k in / 1k out, concurrency 4, 32 prompts):

  before: Accept length 3.26, output 675 tok/s
  after : Accept length 3.97, output 800 tok/s  (+18% throughput)

<!-- Thank you for your contribution! Please follow these guidelines to enhance your pull request. If anything is unclear, submit your PR and reach out to maintainers for assistance. Join our Slack community at https://slack.sglang.io to discuss further. -->

## Motivation

<!-- Describe the purpose and goals of this pull request. -->

## Modifications

<!-- Detail the changes made in this pull request. -->

## Accuracy Tests

<!-- If this pull request affects model outputs (e.g., changes to the kernel or model forward code), provide accuracy test results. -->

## Speed Tests and Profiling

<!-- If this pull request impacts inference speed, provide benchmarking and profiling results. -->

## Checklist

- [ ] Format your code according to the [Format code with pre-commit](https://docs.sglang.io/developer_guide/contribution_guide.html#format-code-with-pre-commit).
- [ ] Add unit tests according to the [Run and add unit tests](https://docs.sglang.io/developer_guide/contribution_guide.html#run-and-add-unit-tests).
- [ ] Update documentation according to [Write documentations](https://docs.sglang.io/developer_guide/contribution_guide.html#write-documentations).
- [ ] Provide accuracy and speed benchmark results according to [Test the accuracy](https://docs.sglang.io/developer_guide/contribution_guide.html#test-the-accuracy) and [Benchmark the speed](https://docs.sglang.io/developer_guide/contribution_guide.html#benchmark-the-speed).
- [ ] Follow the SGLang code style [guidance](https://docs.sglang.io/developer_guide/contribution_guide.html#code-style-guidance).

## Review and Merge Process

1. Ping Merge Oncalls to start the process. See the [PR Merge Process](https://github.com/sgl-project/sglang/blob/main/.github/MAINTAINER.md#pull-request-merge-process).
2. Get approvals from [CODEOWNERS](https://github.com/sgl-project/sglang/blob/main/.github/CODEOWNERS) and other reviewers.
3. Trigger CI tests with [comments](https://docs.sglang.io/developer_guide/contribution_guide.html#how-to-trigger-ci-tests) or contact authorized users to do so.
   - Common commands include `/tag-and-rerun-ci`, `/tag-run-ci-label`, `/rerun-failed-ci`
4. After green CI and required approvals, ask Merge Oncalls or people with Write permission to merge the PR.
